### PR TITLE
use im::HashMap in MemoryDB

### DIFF
--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 parity-util-mem = { version = "0.11.0", default-features = false, features = ["hashbrown"] }
-hash-db = { version = "0.15.2", path = "../hash-db", default-features = false }
+hash-db = { version = "0.15.2", default-features = false }
 im = "15.1.0"
 
 [dev-dependencies]

--- a/memory-db/Cargo.toml
+++ b/memory-db/Cargo.toml
@@ -10,18 +10,11 @@ edition = "2018"
 [dependencies]
 parity-util-mem = { version = "0.11.0", default-features = false, features = ["hashbrown"] }
 hash-db = { version = "0.15.2", path = "../hash-db", default-features = false }
-hashbrown = { version = "0.12.0", default-features = false, features = [ "ahash" ] }
+im = "15.1.0"
 
 [dev-dependencies]
 keccak-hasher = { path = "../test-support/keccak-hasher" }
 criterion = "0.3.3"
-
-[features]
-default = ["std"]
-std = [
-  "hash-db/std",
-  "parity-util-mem/std",
-]
 
 [[bench]]
 name = "bench"


### PR DESCRIPTION
This PR is for reviewing the changes. The whole memory-db source codes are copied into the repo `phala-blockchain`.